### PR TITLE
Maintenance: Add PlatformIO configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea
+/.pio
+/.venv*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+$(eval venvpath  := .venv)
+$(eval python    := $(venvpath)/bin/python)
+$(eval pip       := $(venvpath)/bin/pip)
+$(eval pio       := $(venvpath)/bin/pio)
+
+
+build: setup-virtualenv
+	$(pio) run
+
+upload: setup-virtualenv
+	$(pio) run --target upload --upload-port=${MCU_PORT}
+
+setup-virtualenv:
+	@test -e $(python) || python3 -m venv $(venvpath)
+	$(pip) --quiet install platformio

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,23 @@
+; PlatformIO Project Configuration File for Mois sensor node
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/en/latest/projectconf/
+
+[platformio]
+src_dir = .
+
+[env]
+lib_deps =
+    adafruit/Adafruit SHT31 Library@^2.2
+    adafruit/Adafruit TSL2591 Library@^1.4
+    arduino-libraries/Bridge@^1.7
+    milesburton/DallasTemperature@^3.11
+    paulstoffregen/OneWire@^2.3
+    robtillaart/RunningMedian@^0.3
+    watterott/digitalWriteFast@^1
+    https://github.com/hiveeyes/aerowind-ads1231@^0.1.0
+
+[env:uno]
+platform = atmelavr
+board = uno
+framework = arduino


### PR DESCRIPTION
## About

By using [PlatformIO](https://platformio.org/) for building the Arduino firmware, all users can enjoy reproducible builds, will not have any hassle installing and maintaining a cross-compiler toolchain, and will not have to install the Arduino IDE at all.

## References
- [moislabs/beescale-yun/platformio.ini](https://github.com/hiveeyes/arduino/blob/main/moislabs/beescale-yun/platformio.ini) at the [hiveeyes/arduino](https://github.com/hiveeyes/arduino) repository.
